### PR TITLE
Add support for v0.9.0 features #38 #39 #40 #41

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,11 @@
 
 ## Unreleased
 
+- Added PSRule resource schema. [#39](https://github.com/BernieWhite/PSRule-vscode/issues/39)
+- Updated PSRule options schema to v0.9.0. [#38](https://github.com/BernieWhite/PSRule-vscode/issues/38)
+- Added snippet for baseline resource. [#40](https://github.com/BernieWhite/PSRule-vscode/issues/40)
+- Added highlighting for `Synopsis:` resource comments. [#41](https://github.com/BernieWhite/PSRule-vscode/issues/41)
+
 ## v0.5.0
 
 What's changed since v0.4.0:

--- a/docs/example.Rule.yaml
+++ b/docs/example.Rule.yaml
@@ -1,0 +1,10 @@
+
+---
+# Synopsis: This is an example baseline
+kind: Baseline
+metadata:
+  name: ExampleBaseline
+spec:
+  rule:
+    exclude:
+    - Rule1

--- a/package.json
+++ b/package.json
@@ -45,6 +45,10 @@
             {
                 "language": "markdown",
                 "path": "./snippets/markdown.json"
+            },
+            {
+                "language": "yaml",
+                "path": "./snippets/yaml.json"
             }
         ],
         "grammars": [
@@ -68,6 +72,13 @@
                 "injectTo": [
                     "source.powershell"
                 ]
+            },
+            {
+                "path": "./syntaxes/yaml-comments.json",
+                "scopeName": "PSRule-yaml-comments",
+                "injectTo": [
+                    "source.yaml"
+                ]
             }
         ],
         "yamlValidation": [
@@ -86,6 +97,10 @@
             {
                 "fileMatch": "psrule.yml",
                 "url": "./schemas/PSRule-options.schema.json"
+            },
+            {
+                "fileMatch": "**/*.Rule.yaml",
+                "url": "./schemas/PSRule-language.schema.json"
             }
         ]
     },

--- a/schemas/PSRule-language.schema.json
+++ b/schemas/PSRule-language.schema.json
@@ -1,0 +1,141 @@
+{
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "title": "PSRule language",
+    "description": "A schema for PSRule YAML language files.",
+    "oneOf": [
+        {
+            "$ref": "#/definitions/baseline"
+        }
+    ],
+    "definitions": {
+        "resource-metadata": {
+            "type": "object",
+            "title": "Metadata",
+            "description": "Additional information to identify the resource.",
+            "properties": {
+                "name": {
+                    "type": "string",
+                    "title": "Name",
+                    "description": "The name of the resource. This must be unique.",
+                    "minLength": 3
+                }
+            },
+            "required": [
+                "name"
+            ]
+        },
+        "baseline": {
+            "type": "object",
+            "properties": {
+                "kind": {
+                    "type": "string",
+                    "title": "Kind",
+                    "description": "The type of PSRule resource.",
+                    "enum": [
+                        "Baseline"
+                    ]
+                },
+                "metadata": {
+                    "type": "object",
+                    "$ref": "#/definitions/resource-metadata"
+                },
+                "spec": {
+                    "type": "object",
+                    "$ref": "#/definitions/baseline-spec"
+                }
+            },
+            "required": [
+                "kind",
+                "metadata",
+                "spec"
+            ],
+            "additionalProperties": false
+        },
+        "baseline-spec": {
+            "type": "object",
+            "title": "Baseline",
+            "description": "A specification for a baseline.",
+            "properties": {
+                "binding": {
+                    "type": "object",
+                    "title": "Object binding",
+                    "description": "Configure property/ object binding options.",
+                    "properties": {
+                        "ignoreCase": {
+                            "type": "boolean",
+                            "title": "Ignore case",
+                            "description": "Determines if custom binding uses ignores case when matching properties. The default is true.",
+                            "default": true
+                        },
+                        "targetName": {
+                            "type": "array",
+                            "title": "Bind TargetName",
+                            "description": "Specifies one or more property names to bind TargetName to.",
+                            "items": {
+                                "type": "string"
+                            },
+                            "uniqueItems": true
+                        },
+                        "targetType": {
+                            "type": "array",
+                            "title": "Bind TargetType",
+                            "description": "Specifies one or more property names to bind TargetType to.",
+                            "items": {
+                                "type": "string"
+                            },
+                            "uniqueItems": true
+                        }
+                    },
+                    "additionalProperties": false
+                },
+                "configuration": {
+                    "type": "object",
+                    "title": "Configuration",
+                    "description": "Baseline specific configuration options.",
+                    "uniqueItems": true
+                },
+                "rule": {
+                    "type": "object",
+                    "title": "Rule",
+                    "description": "A filter for included or excluded rules.",
+                    "properties": {
+                        "include": {
+                            "type": "array",
+                            "title": "Include rules",
+                            "description": "Rules to include by name in the baseline.",
+                            "$ref": "#/definitions/rule-names"
+                        },
+                        "exclude": {
+                            "type": "array",
+                            "title": "Exclude rules",
+                            "description": "Rules to exclude by name from the baseline.",
+                            "$ref": "#/definitions/rule-names"
+                        },
+                        "tag": {
+                            "type": "object",
+                            "title": "Tags",
+                            "description": "Rules to include by tag in the baseline.",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    "additionalProperties": false
+                }
+            },
+            "additionalProperties": false
+        },
+        "rule-names": {
+            "type": "array",
+            "items": {
+                "type": "string",
+                "$ref": "#/definitions/rule-name"
+            },
+            "uniqueItems": true
+        },
+        "rule-name": {
+            "type": "string",
+            "minLength": 3
+        }
+    }
+}

--- a/schemas/PSRule-options.schema.json
+++ b/schemas/PSRule-options.schema.json
@@ -8,36 +8,10 @@
         }
     ],
     "definitions": {
-        "baseline-v0.2.0": {
+        "configuration": {
             "type": "object",
-            "title": "Baseline options",
-            "description": "Options that include/ exclude and configure rules.",
-            "properties": {
-                "ruleName": {
-                    "type": "array",
-                    "title": "Include rules",
-                    "description": "Optionally filter to rules by name.",
-                    "items": {
-                        "type": "string"
-                    },
-                    "uniqueItems": true
-                },
-                "exclude": {
-                    "type": "array",
-                    "title": "Exclude rules",
-                    "description": "Specifies rules to exclude by name.",
-                    "items": {
-                        "type": "string"
-                    },
-                    "uniqueItems": true
-                },
-                "configuration": {
-                    "type": "object",
-                    "title": "Configuration values",
-                    "description": "A set of key/ value configuration options for rules."
-                }
-            },
-            "additionalProperties": false
+            "title": "Configuration values",
+            "description": "A set of key/ value configuration options for rules."
         },
         "binding-v0.3.0": {
             "type": "object",
@@ -270,19 +244,19 @@
         },
         "options-v0.8.0": {
             "properties": {
-                "baseline": {
-                    "type": "object",
-                    "oneOf": [
-                        {
-                            "$ref": "#/definitions/baseline-v0.2.0"
-                        }
-                    ]
-                },
                 "binding": {
                     "type": "object",
                     "oneOf": [
                         {
                             "$ref": "#/definitions/binding-v0.3.0"
+                        }
+                    ]
+                },
+                "configuration": {
+                    "type": "object",
+                    "oneOf": [
+                        {
+                            "$ref": "#/definitions/configuration"
                         }
                     ]
                 },
@@ -318,6 +292,14 @@
                         }
                     ]
                 },
+                "rule": {
+                    "type": "object",
+                    "oneOf": [
+                        {
+                            "$ref": "#/definitions/rule-option"
+                        }
+                    ]
+                },
                 "suppression": {
                     "type": "object",
                     "oneOf": [
@@ -328,6 +310,46 @@
                 }
             },
             "additionalProperties": false
+        },
+        "rule-option": {
+            "type": "object",
+            "title": "Baseline options",
+            "description": "Options that include/ exclude and configure rules.",
+            "properties": {
+                "include": {
+                    "type": "array",
+                    "title": "Include rules",
+                    "description": "Optionally filter to rules by name.",
+                    "$ref": "#/definitions/rule-names"
+                },
+                "exclude": {
+                    "type": "array",
+                    "title": "Exclude rules",
+                    "description": "Specifies rules to exclude by name.",
+                    "$ref": "#/definitions/rule-names"
+                },
+                "tag": {
+                    "type": "object",
+                    "title": "Tags",
+                    "description": "Rules to include by tag in the baseline.",
+                    "additionalProperties": {
+                        "type": "string"
+                    }
+                }
+            },
+            "additionalProperties": false
+        },
+        "rule-names": {
+            "type": "array",
+            "items": {
+                "type": "string",
+                "$ref": "#/definitions/rule-name"
+            },
+            "uniqueItems": true
+        },
+        "rule-name": {
+            "type": "string",
+            "minLength": 3
         }
     }
 }

--- a/snippets/yaml.json
+++ b/snippets/yaml.json
@@ -1,0 +1,15 @@
+{
+    "baseline": {
+        "prefix": "baseline",
+        "description": "Baseline spec",
+        "body": [
+            "---",
+            "# Synopsis: ${2}",
+            "kind: Baseline",
+            "metadata:",
+            "  name: ${1}",
+            "spec:",
+            "  ${3}"
+        ]
+    }
+}

--- a/syntaxes/yaml-comments.json
+++ b/syntaxes/yaml-comments.json
@@ -1,0 +1,15 @@
+{
+    "scopeName": "PSRule-yaml-comments",
+    "injectionSelector": "L:comment.line.number-sign.yaml",
+    "patterns": [
+        {
+            "include": "#synopsis-comment"
+        }
+    ],
+    "repository": {
+        "synopsis-comment": {
+            "match": "Synopsis:",
+            "name": "keyword.operator.documentation.powershell"
+        }
+    }
+}


### PR DESCRIPTION
## PR Summary

- Added PSRule resource schema. #39
- Updated PSRule options schema to v0.9.0. #38
- Added snippet for baseline resource. #40
- Added highlighting for `Synopsis:` resource comments. #41

Fixes #39 
Fixes #38 
Fixes #40 
Fixes #41 

## PR Checklist

- [x] PR has a meaningful title
- [x] Summarized changes
- [x] Change is not breaking
- [x] This PR is ready to merge and is not **Work in Progress**
- **Code changes**
  - [x] Link to a filed issue
  - [x] [Change log](https://github.com/BernieWhite/PSRule-vscode/blob/master/CHANGELOG.md) has been updated with change under unreleased section
